### PR TITLE
QoD: Add links to the API reference

### DIFF
--- a/catalog/qod/qod.md
+++ b/catalog/qod/qod.md
@@ -27,32 +27,29 @@ The QoD CAMARA API specifies the following three operations:
   - `ueId`: User equipment identifier ;
   - `asId`: Application server identifier ;
   - `qos` : Enum: "QOS_E" (Qualifier for enhanced communication profile),  "QOS_S" (Qualifier for the requested QoS profile S), "QOS_M" (Qualifier for the requested QoS profile M) ,  "QOS_L" (Qualifier for the requested QoS profile L);
-
-
   
-Other parameters :
-  - `duration`: Session duration in seconds (maximal value of 24 hours is used if not set);
-  - `uePorts` : Ports may be specified as a list of ranges or single ports ;
-  - `asPorts` : Ports may be specified as a list of ranges or single ports ;
-  - `notificationUri` : Allows asynchronous delivery of session related events ;
-  - `notificationAuthToken` : Authentication token for callback API ;
+  Other parameters :
+    - `duration`: Session duration in seconds (maximal value of 24 hours is used if not set);
+    - `uePorts` : Ports may be specified as a list of ranges or single ports ;
+    - `asPorts` : Ports may be specified as a list of ranges or single ports ;
+    - `notificationUri` : Allows asynchronous delivery of session related events ;
+    - `notificationAuthToken` : Authentication token for callback API ;
 
-<!-- [Check the API Reference](/reference/) -->
+[Check the API Reference](/reference/createsession)
 
 - **GET Get session information:** An operation to get the information about a specific QoD provisioning.Path parameter required:  
 
   - `sessionId`:Session ID that was obtained from the createSession operation.
 
-<!-- [Check the API Reference](/reference/) -->
+[Check the API Reference](/reference/getsession)
 
 - **DELETE Free resources related to QoS session:** An operation to terminate a QoD provisioning, identified by Id .  Path parameter required:  
 
   - `sessionId`: Session ID that was obtained from the createSession operation.
 
-<!-- [Check the API Reference](/reference/) -->
+[Check the API Reference](/reference/deletesession)
 
 By utilizing the QoD Service, developers of applications can capitalize on the usability, ubiquity, security, quickness, and simplicity of the APIs to manage their End Users networking and focus on the experiences they want to offer.
-
 
 ## Why QoD?
 


### PR DESCRIPTION
QoD API guide was lacking the API Reference. Now it is in place, links are to be included