### PR TITLE
Add note about login_hint being mandatory in production mode to check…

### DIFF
--- a/callflows/authorization/authorization_openapi.yaml
+++ b/callflows/authorization/authorization_openapi.yaml
@@ -26,6 +26,8 @@ paths:
         - {}
       description: |
         Authorizes an application to access a resource from the user device
+
+        **NOTE**: In case you are using our Sandbox as a host, please take into account that the `login_hint` parameter, although optional according to the OpenID Connect specification, is mandatory in order to inform about the end-user identifier so the Sandbox checks its whitelist for privacy reasons. Check the [Whitelist](/docs/sandbox/whitelist) guide for more information.
       operationId: authorize
       parameters: 
         - name: response_type

--- a/gettingstarted/sandbox/whitelist.md
+++ b/gettingstarted/sandbox/whitelist.md
@@ -1,0 +1,18 @@
+---
+title: Sandbox line whitelist
+excerpt: Get familiar with our Sandbox's whitelist and how it's meant to guard our operators' customers' privacy.
+path: docs/sandbox/whitelist
+category: 66d5624a492663000f4ed527
+---
+
+## On privacy
+
+Having actual operator's mobile lines in you whitelist is mandatory for testing the APIs in the production mode. This way, you as a tester can make real calls to the operators' APIs and get real responses without compromising anyone else's privacy by accessing just your own line's data.
+
+Check the [Privacy](../../about/privacy.md) section for more information on why Open Gateway is Privacy by Design.
+
+## Adding your mobile lines to the whitelist
+
+In order to add your lines to the whitelist, just fill-in the text fields at the bottom of the [production environments access application form](https://opengateway.telefonica.com/en/sandbox/registration). Our Developer Hub support team will review your request and will get back to you with the confirmation of the addition of your lines to the whitelist.
+
+In coming releases, you will be able to manage your whitelist from the Sandbox console.


### PR DESCRIPTION
… the whitelist

Just a note in the auth code API reference about login_hint being mandatory

And a subpage in the Sandbox folder about the whitelist