### PR TITLE
Improve callouts and fix some broken links

### DIFF
--- a/about/architecture.md
+++ b/about/architecture.md
@@ -4,8 +4,6 @@ excerpt: The Open Gateway API Architecture is a cutting-edge framework designed 
 category: 66840b9dac745a002559ffad
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 ## Introduction to Open Gateway API Architecture
 
 The Open Gateway APIs manages API calls and credentials, ensuring they are routed correctly to respective mobile operators. Its intuitive interface enables developers to effortlessly choose and subscribe to network APIs offered by multiple operators across different regions. This transforms Open Gateway into a convenient marketplace that simplifies procurement processes while maintaining a seamless user experience.

--- a/about/camara.md
+++ b/about/camara.md
@@ -3,8 +3,6 @@ title: CAMARA project
 excerpt: CAMARA is an open-source initiative under the Linux Foundation focused on defining, developing, and testing telecom APIs. In collaboration with the GSMA Operator Platform Group, CAMARA ensures that API requirements are aligned, and API definitions are published for industry-wide use. The project achieves API harmonization by rapidly creating working code and providing developer-friendly documentation. All API definitions and reference implementations are available for free under the Apache 2.0 license.
 category: 66840b9dac745a002559ffad
 ---
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 
 With CAMARA Open APIs, enterprise software developers can integrate network capabilities once, and they’re ready to go. Imagine these APIs embedded in cloud provider stacks. Developers could then seamlessly incorporate lines of code from both the cloud provider and global telecommunication standards, covering services like identity, cybersecurity, billing, signaling, geolocation, and more.
 

--- a/about/glossary.md
+++ b/about/glossary.md
@@ -4,8 +4,6 @@ excerpt: Reference guide to key terms and concepts used in the Open Gateway API 
 category: 66840b9dac745a002559ffad
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 ## Aggregator
 Aggregator or ‘Channel Partners’ aggregate Operator’s CAMARA standardized APIs to build Open Gateway-based services and implement Operator end-point routing based on final user identification on the network.
 

--- a/about/initiative.md
+++ b/about/initiative.md
@@ -4,8 +4,6 @@ excerpt: Welcome to Open Gateway APIs, your gateway to leveraging advanced netwo
 category: 66840b9dac745a002559ffad
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 ## What is Open Gateway?
 
 Open Gateway is a initiative spearheaded by the [GSMA](https://www.gsma.com/solutions-and-impact/gsma-open-gateway/) in collaboration with leading telecommunications operators, cloud providers, and aggregators worldwide. Our mission is to create a standardized framework of Application Programming Interfaces (APIs) that enable simplified and universal access to cutting-edge mobile network capabilities and associated services. By leveraging Open Gateway APIs, developers can focus on building exceptional applications while we handle the complexities of network integration.
@@ -47,9 +45,10 @@ Getting started with Open Gateway APIs is easy:
 4. **Read the Documentation:** Familiarize yourself with our comprehensive documentation to understand [how to make API calls](../gettingstarted/apireference.md), handle responses, and implement best practices.
 5. **Start Building:** Begin integrating Open Gateway APIs into your applications, leveraging the powerful network capabilities to create innovative and high-performance solutions.
 
+> 📘 Want to give Open Gateway APIs a try?
+> Apply to join the [Developer Hub](https://opengateway.telefonica.com/en/developer-hub) and gain access to our Sandbox.
 
 ## Join the Open Gateway Community
-
 
 Open Gateway APIs open up a world of possibilities for developers looking to harness the power of advanced network capabilities. Our standardized, secure, and easy-to-use APIs provide the foundation for creating exceptional applications that meet the demands of today's connected world. Start your journey with Open Gateway today and transform your ideas into reality.
 

--- a/about/privacy.md
+++ b/about/privacy.md
@@ -4,8 +4,6 @@ excerpt: Open Gateway as an industry initiative has been designed with end-user'
 category: 66840b9dac745a002559ffad
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 Open Gateway APIs allow applications to access and utilize end-users' personal information or data. "Utilizing" personal data encompasses any form of handling or processing related to an identified or identifiable individual, including merely viewing the data or having it accesible from the application's code and thus to its developer. Consequently, **the use of personal data must be justified and authorized**.
 
 Open Gateway as an initiative from the telco companies has been designed with their subscribers, the applications’ end-users, privacy in mind.

--- a/callflows/apiintegration.md
+++ b/callflows/apiintegration.md
@@ -4,8 +4,6 @@ excerpt: In this guide we will go through the different ways to integrate with O
 category: 66d57750d3f60b0011576376
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 ## RESTful by design 
 
 Since Open Gateway APIs are RESTful, you will always be able to integrate them by performing HTTP requests from any programming language providing such capability. However, most Channel Partners will provide you with SDKs in several programming languages which, by performing such requests themselves under the hood, will make your life easier when it comes to accessing the telco features that Open Gateway offers to your application.
@@ -41,3 +39,6 @@ These are some pros and cons you could get from the following two ways of integr
 	- It is up to your Channel Partner to provide SDKs in different programming languages including your app's one
 	- Depending on your Channel Partner and your use case, you could need to implement a frontend authorization flow and there could be a lack of frontend SDKs (e.g. for native mobile apps) which would lead you to integrate the frontend authorization by performing HTTP requests anyway
 	- Once you have integrated the SDKs from a Channel Partner, you would need some re-engineering to switch to another Channel Partner's Open Gateway platform, since each one offer their owns and SDK interfaces are not standardized at CAMARA.
+
+> 📘 Want to give Open Gateway APIs a try?
+> Apply to join the [Developer Hub](https://opengateway.telefonica.com/en/developer-hub) and gain access to our Sandbox.

--- a/callflows/authorization/authorization.md
+++ b/callflows/authorization/authorization.md
@@ -4,8 +4,6 @@ excerpt: In this guide you will find a briefly introduction to authorization mec
 category: 66d57750d3f60b0011576376
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 ## Authorization standards
 
 As standardized by CAMARA, Open Gateway API access will be secured using [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) (OIDC) on top of OAuth 2.0 protocol. Operators are aligned in introducing the concept of **purpose** in order to fully comply with data protection regulations, such as the GDPR regulation in Europe, to protect user privacy. More on this in the [Privacy guide](/docs/privacy).

--- a/callflows/authorization/backend.md
+++ b/callflows/authorization/backend.md
@@ -4,8 +4,6 @@ excerpt: If your use case does not involve end-user's interaction you will want 
 category: 66d57750d3f60b0011576376
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 From a developer perspective, the backend authorization flow consists of two sequential steps implemented by performing HTTP requests to the following Open Gateway Channel Partner's API gateway endpoints, compliant with the ODIC standard **CIBA** (Client-Initiated Backchannel Authentication Flow).
 
 ## Backend authorization flow steps
@@ -66,7 +64,10 @@ curl --request POST \
 [Check the API reference](/reference/token)
 
 Once you get the access token, you can use it to authorize you HTTP request to the Open Gateway service API accordingly with the `scope` passed as a value in the authorization request above.
-	
+
+> 📘 Want to give it a try?
+> Apply to join the [Developer Hub](https://opengateway.telefonica.com/en/developer-hub) and gain access to our Sandbox.
+
 ## Backend authorization flow sequence diagram
 
 ![Backend Authorization Flow Sequence Diagram](https://github.com/Telefonica/opengateway-developers-website/raw/main/callflows/authorization/diagrams/backend.svg?autoSizes=true)

--- a/callflows/authorization/frontend.md
+++ b/callflows/authorization/frontend.md
@@ -4,8 +4,6 @@ excerpt: If your application offers a human interface to provide your users with
 category: 66d57750d3f60b0011576376
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 From a developer perspective, the frontend authorization flow consists of two sequential steps implemented by performing HTTP requests to the following Open Gateway Channel Partner's API gateway endpoints, compliant with the OIDC standard **Authorization Code Flow**.
 
 ## Frontend authorization flow steps
@@ -51,6 +49,9 @@ curl --request GET \
 ```
 
 [Check the API reference](/reference/authorize)
+
+> 📘 Want to give it a try?
+> Apply to join the [Developer Hub](https://opengateway.telefonica.com/en/developer-hub) and gain access to our Sandbox.
 
 ### Access token retrieval
 The authorization code received in the previous step will be used to get an access token from the Channel Partner's API gateway, by performing a POST request to the token endpoint.

--- a/catalog/available.md
+++ b/catalog/available.md
@@ -4,13 +4,14 @@ excerpt: The Open Gateway initiative is led to create a standardized framework o
 category: 66aa4f941e51e7000fa353ce
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 Open Gateway enables software developers to leverage Telco Application Programming Interfaces (Telco APIs) for building applications that seamlessly integrate our underlying networks' capabilities and operators' data. These APIs provide a consistent method for accessing analytical and statistical data from networks, facilitating the implementation of customer experience-focused use cases. Open Gateway empowers developers to retrieve network information and request configuration changes efficiently.
 
 Open Gateway utilizes these Telco APIs to offer a unified standard interface across multiple operator networks worldwide, abstracting the inherent complexities associated with their systems and infrastructures. This approach simplifies integration and enhances interoperability for developers and applications alike.
 
 ![available_apis](https://github.com/Telefonica/opengateway-developers-website/raw/main/catalog/images/available_apis.png)
+
+> 📘 Want to give Open Gateway APIs a try?
+> Apply to join the [Developer Hub](https://opengateway.telefonica.com/en/developer-hub) and gain access to our Sandbox.
 
 ## Technical Description of Open Gateway APIs
 

--- a/catalog/devicelocation/devicelocation.md
+++ b/catalog/devicelocation/devicelocation.md
@@ -4,8 +4,6 @@ excerpt: The Device Location API from Open Gateway allows to check if a mobile p
 category: 66aa4f941e51e7000fa353ce
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 The Device Location API is a software interface that allows applications to confirm if a user's device is in its intended location. The network must track a device's location at all times to effectively provide telecommunications services. This capability is utilized to offer device location as a service.
 
 The Device Location API enhances security by verifying that a device is in the expected location during transactions, which helps prevent fraud and unauthorized activities. This verification process also streamlines authentication, leading to faster and smoother transactions, ultimately improving the user experience. 
@@ -15,6 +13,9 @@ Additionally, the API is a valuable tool for fraud prevention, as it can quickly
 Furthermore, by knowing a user's location, businesses can offer more personalized and context-aware services, increasing customer engagement and satisfaction. The API's versatility makes it applicable across various industries, including retail, telecom, and logistics. For merchants, it also contributes to reducing chargebacks by verifying the location of a device during transactions.
 
 ![DeviceLocation](https://github.com/Telefonica/opengateway-developers-website/raw/main/catalog/devicelocation/images/DeviceLocation.png)
+
+> 📘 Want to give it a try?
+> Apply to join the [Developer Hub](https://opengateway.telefonica.com/en/developer-hub) and gain access to our Sandbox.
 
 ## Overview of the SIM Swap CAMARA API
 

--- a/catalog/devicelocation/samplecode_devicelocation.md
+++ b/catalog/devicelocation/samplecode_devicelocation.md
@@ -6,7 +6,8 @@ category: 66aa4f941e51e7000fa353ce
 
 The following code shows, for didactic purposes, a hypothetical or sample SDK, in several programming languages, from a generic Open Gateway's channel partner, also known as aggregator. The final implementation will depend on the channel partner's development tools offering. Note that channel partners' Open Gateway SDKs are just code modules wrapping authorization and API calls providing an interface in your app's programming for convenience.
 
-> 📘 It is recommended to use the [API Reference tool](https://developers.opengateway.telefonica.com/reference/) for faster calls of our APIs
+> 📘 Want to give it a try before coding?
+> Check the [API interactive reference](https://developers.opengateway.telefonica.com/reference/verifylocation-1)
 
 ### Table of contents
 - [Backend flow](#backend-flow)
@@ -14,9 +15,13 @@ The following code shows, for didactic purposes, a hypothetical or sample SDK, i
     - [API usage](#api-usage)
 
 ## Code samples
-> 📘 These are code examples
-> - Remember to replace 'my-app-id' and 'my-app-secret' with the credentials of your app. (If you are using our Sandbox, you can get them [here](https://sandbox.opengateway.telefonica.com/my-apps)).
-> - Remember also to change the urls with your aggregator urls. If you are using the Sandbox, the url is https://sandbox.opengateway.telefonica.com/apigateway/
+
+> 📘 Note
+> These are code samples and not finalized ready-to-run code:
+> - Remember to replace 'my-app-id' and 'my-app-secret' with the credentials of your app.
+If you registered your test app on our Sandbox, you can retrieve its credentials [here](https://sandbox.opengateway.telefonica.com/my-apps). 
+> - Remember also to replace "aggregator/opengateway-sdk" with the SDK from your aggregator.
+If you are using our sandbox SDK, check info and installation of de Sandbox SDK [here](/docs/sdkreference)
 
 ### Backend flow
 

--- a/catalog/devicestatus/devicestatus.md
+++ b/catalog/devicestatus/devicestatus.md
@@ -4,13 +4,14 @@ excerpt: The Device Status API makes it possible to check the roaming status of 
 category: 66aa4f941e51e7000fa353ce
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 The standardised Device Status API provides the ability to check the roaming status of a given SIM-based device without identity theft or GPS.
 
 This solution allows you to control resource management during international roaming in a more secure way.
 
 ![DeviceStatus](https://github.com/Telefonica/opengateway-developers-website/raw/main/catalog/devicestatus/images/DeviceStatus.png)
+
+> 📘 Want to give it a try?
+> Apply to join the [Developer Hub](https://opengateway.telefonica.com/en/developer-hub) and gain access to our Sandbox.
 
 ## Overview of the Device Status API
 

--- a/catalog/devicestatus/samplecode_devicestatus.md
+++ b/catalog/devicestatus/samplecode_devicestatus.md
@@ -10,7 +10,8 @@ This sample code consumes the API without an SDK, using direct HTTP requests. Ho
 
 Note that currently, our Sandbox SDK does not have Device Status implemented.
 
-> 📘 It is recommended to use the [API Reference tool](https://developers.opengateway.telefonica.com/reference/) for faster calls of our APIs
+> 📘 Want to give it a try before coding?
+> Check the [API interactive reference](https://developers.opengateway.telefonica.com/reference/getroamingstatus)
 
 ### Table of contents
 - [Backend flow](#backend-flow)
@@ -18,9 +19,13 @@ Note that currently, our Sandbox SDK does not have Device Status implemented.
     - [API usage](#api-usage)
 
 ## Code samples
-> 📘 These are code examples
-> - Remember to replace 'my-app-id' and 'my-app-secret' with the credentials of your app. (If you are using our Sandbox, you can get them [here](https://sandbox.opengateway.telefonica.com/my-apps)).
-> - Remember also to change the urls with your aggregator urls. If you are using the Sandbox, the url is https://sandbox.opengateway.telefonica.com/apigateway/
+
+> 📘 Note
+> These are code samples and not finalized ready-to-run code:
+> - Remember to replace 'my-app-id' and 'my-app-secret' with the credentials of your app.
+If you registered your test app on our Sandbox, you can retrieve its credentials [here](https://sandbox.opengateway.telefonica.com/my-apps). 
+> - Remember also to replace "aggregator/opengateway-sdk" with the SDK from your aggregator.
+If you are using our sandbox SDK, check info and installation of de Sandbox SDK [here](/docs/sdkreference)
 
 ### Backend flow
 

--- a/catalog/knowyourcustomer/knowyourcustomer.md
+++ b/catalog/knowyourcustomer/knowyourcustomer.md
@@ -4,12 +4,12 @@ excerpt: The Know Your Customer API makes it possible to validates users info wi
 category: 66aa4f941e51e7000fa353ce
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 The standardised Know Your Customer API allows you to validate user contact information against data from Mobile Network Operators (MNOs), ensuring accuracy and improving both conversion rates and the quality of user onboarding for new services.
 
 This API provides a quick and efficient method to verify customer contact details, helping you prevent identity fraud, including synthetic identities and identity theft. Additionally, by utilizing this standardized API, you can expand your user reach across multiple MNOs.
 
+> 📘 Want to give it a try?
+> Apply to join the [Developer Hub](https://opengateway.telefonica.com/en/developer-hub) and gain access to our Sandbox.
 
 ## Overview of the Know Your Customer API
 

--- a/catalog/numberverification/numberverification.md
+++ b/catalog/numberverification/numberverification.md
@@ -4,9 +4,10 @@ excerpt: The Number Verification API is a pivotal tool for bolstering security a
 category: 66aa4f941e51e7000fa353ce
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 Built as part of the Open Gateway initiative, the Number Verification API provides developers universal access to essential network functionalities. Whether you're enhancing user registration processes, securing transactions, or optimizing user engagement strategies, integrating the Number Verification API enriches your application's security posture while ensuring a seamless user experience.
+
+> 📘 Want to give it a try?
+> Apply to join the [Developer Hub](https://opengateway.telefonica.com/en/developer-hub) and gain access to our Sandbox.
 
 ## Overview of the Number Verification CAMARA API
 

--- a/catalog/numberverification/samplecode_numberverification.md
+++ b/catalog/numberverification/samplecode_numberverification.md
@@ -4,17 +4,14 @@ excerpt: The following samples show how to use the [Open Gateway Number Verifica
 category: 66aa4f941e51e7000fa353ce
 ---
 
-> 📘 Note
->
-> To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 Although the API consumption flow for this API must be always triggered from such end-user's device - therefore from the application's frontend - according to its intrinsic feature, the flow will always complete on the backend. The following code shows, for didactic purposes, a hypothetical or sample SDK used on the backend, in several programming languages, from a generic Open Gateway's channel partner, also known as aggregator.
 
 The final implementation will depend on the channel partner's development tools offering. Some of them might even provide you with both backend SDKs and frontend SDKs, the latter handling details such as network interface switching for proper mobile line identification. Apart from this extra frontend features (available upon channel partner discretion), note that channel partners' Open Gateway SDKs are just code modules wrapping authentication and API calls providing an interface in your app's programming for convenience.
 
 Sample code on how to consume the API without an SDK, directly with HTTP requests, is also provided, and it is common and valid no matter what your partner is, thanks to the CAMARA standardization. If you do not use an SDK you need to code the HTTP calls and additional stuff like encoding your credentials, calling authorization endpoints, handling tokens, etc. You can check our sample [Postman collection](https://github.com/Telefonica/opengateway-postman) as a reference.
 
-> 📘 It is recommended to use the [API Reference tool](https://developers.opengateway.telefonica.com/reference/) for faster calls of our APIs
+> 📘 Want to give it a try before coding?
+> Check the [API interactive reference](https://developers.opengateway.telefonica.com/reference/phonenumberverify)
 
 ### Table of contents
 - [Frontend](#frontend)
@@ -24,9 +21,13 @@ Sample code on how to consume the API without an SDK, directly with HTTP request
     - [Using the service API](#using-the-service-api)
 
 ## Code samples
-> 📘 These are code examples
-> - Remember to replace 'my-app-id' and 'my-app-secret' with the credentials of your app. (If you are using our Sandbox, you can get them [here](https://sandbox.opengateway.telefonica.com/my-apps)). 
-> - Remember also to replace "aggregator/opengateway-sdk" with the SDK from your aggregator. If you are using our sandbox SDK, check info and installation of de Sandbox SDK [here](../../gettingstarted/sandbox/sdkreference.md)
+
+> 📘 Note
+> These are code samples and not finalized ready-to-run code:
+> - Remember to replace 'my-app-id' and 'my-app-secret' with the credentials of your app.
+If you registered your test app on our Sandbox, you can retrieve its credentials [here](https://sandbox.opengateway.telefonica.com/my-apps). 
+> - Remember also to replace "aggregator/opengateway-sdk" with the SDK from your aggregator.
+If you are using our sandbox SDK, check info and installation of de Sandbox SDK [here](/docs/sdkreference)
 
 ### Frontend
 

--- a/catalog/qod/qod.md
+++ b/catalog/qod/qod.md
@@ -4,12 +4,13 @@ excerpt: The QoD API allows the developer to prioritize network traffic on certa
 category: 66aa4f941e51e7000fa353ce
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 An example of an application that aims to enrich the public experience when attending a live sporting event, an advanced feature for your viewers may be watching replays of relevant games. 
 
 To do this, the application must ensure that the end user has adequate connectivity to watch it, regardless of the
 number of simultaneous users watching the sporting event in the same location. 
+
+> 📘 Want to give it a try?
+> Apply to join the [Developer Hub](https://opengateway.telefonica.com/en/developer-hub) and gain access to our Sandbox.
 
 ## Overview of the QoD CAMARA API
 

--- a/catalog/qod/samplecode_qod.md
+++ b/catalog/qod/samplecode_qod.md
@@ -4,15 +4,12 @@ excerpt: The following samples show how to use the [Open Gateway Quality on Dema
 category: 66aa4f941e51e7000fa353ce
 ---
 
-> 📘 Note
->
-> To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 The following code shows, for didactic purposes, a hypothetical SDK, in several programming languages, from a generic Open Gateway's channel partner, also known as aggregator. The final implementation will depend on the channel partner's development tools offering. Note that channel partners' Open Gateway SDKs are just code modules wrapping authentication and API calls providing an interface in your app's programming for convenience.
 
 Sample code on how to consume the API without an SDK, directly with HTTP requests, is also provided, and it is common and valid no matter what your partner is, thanks to the CAMARA standardization. If you do not use an SDK you need to code the HTTP calls and additional stuff like encoding your credentials, calling authorization endpoints, handling tokens, etc. You can check our sample [Postman collection](https://github.com/Telefonica/opengateway-postman) as a reference.
 
-> 📘 It is recommended to use the [API Reference tool](https://developers.opengateway.telefonica.com/reference/) for faster calls of our APIs
+> 📘 Want to give it a try before coding?
+> Check the [API interactive reference](https://developers.opengateway.telefonica.com/reference/createsession)
 
 ### Table of contents
 - [Backend flow](#backend-flow)
@@ -24,9 +21,13 @@ Sample code on how to consume the API without an SDK, directly with HTTP request
     - [API Usage](#api-usage-1)
 
 ## Code samples
-> 📘 These are code examples
-> - Remember to replace 'my-app-id' and 'my-app-secret' with the credentials of your app. (If you are using our Sandbox, you can get them [here](https://sandbox.opengateway.telefonica.com/my-apps)).
-> - Remember also to replace "aggregator/opengateway-sdk" with the SDK from your aggregator. If you are using our sandbox SDK, check info and installation of de Sandbox SDK [here](../../gettingstarted/sandbox/sdkreference.md)
+
+> 📘 Note
+> These are code samples and not finalized ready-to-run code:
+> - Remember to replace 'my-app-id' and 'my-app-secret' with the credentials of your app.
+If you registered your test app on our Sandbox, you can retrieve its credentials [here](https://sandbox.opengateway.telefonica.com/my-apps). 
+> - Remember also to replace "aggregator/opengateway-sdk" with the SDK from your aggregator.
+If you are using our sandbox SDK, check info and installation of de Sandbox SDK [here](/docs/sdkreference)
 
 ### Backend flow
 

--- a/catalog/simswap/samplecode_simswap.md
+++ b/catalog/simswap/samplecode_simswap.md
@@ -4,15 +4,12 @@ excerpt: The following samples show how to use the [Open Gateway SIM Swap API](h
 category: 66aa4f941e51e7000fa353ce
 ---
 
-> 📘 Note
->
-> To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 The following code shows, for didactic purposes, a hypothetical or sample SDK, in several programming languages, from a generic Open Gateway's channel partner, also known as aggregator. The final implementation will depend on the channel partner's development tools offering. Note that channel partners' Open Gateway SDKs are just code modules wrapping authorization and API calls providing an interface in your app's programming for convenience.
 
 Sample code on how to consume the API without an SDK, directly with HTTP requests, is also provided, and it is common and valid no matter what your partner is, thanks to the CAMARA standardization. If you do not use an SDK you need to code the HTTP calls and additional stuff like encoding your credentials, calling authorization endpoints, handling tokens, etc. You can check our sample [Postman collection](https://github.com/Telefonica/opengateway-postman) as a reference.
 
-> 📘 It is recommended to use the [API Reference tool](https://developers.opengateway.telefonica.com/reference/) for faster calls of our APIs
+> 📘 Want to give it a try before coding?
+> Check the [API interactive reference](https://developers.opengateway.telefonica.com/reference/checksimswap)
 
 ### Table of contents
 - [Backend flow](#backend-flow)
@@ -25,9 +22,13 @@ Sample code on how to consume the API without an SDK, directly with HTTP request
     - [API usage](#api-usage-1)
 
 ## Code samples
-> 📘 These are code examples
-> - Remember to replace 'my-app-id' and 'my-app-secret' with the credentials of your app. (If you are using our Sandbox, you can get them [here](https://sandbox.opengateway.telefonica.com/my-apps)).
-> - Remember also to replace "aggregator/opengateway-sdk" with the SDK from your aggregator. If you are using our sandbox SDK, check info and installation of de Sandbox SDK [here](../../gettingstarted/sandbox/sdkreference.md)
+
+> 📘 Note
+> These are code samples and not finalized ready-to-run code:
+> - Remember to replace 'my-app-id' and 'my-app-secret' with the credentials of your app.
+If you registered your test app on our Sandbox, you can retrieve its credentials [here](https://sandbox.opengateway.telefonica.com/my-apps). 
+> - Remember also to replace "aggregator/opengateway-sdk" with the SDK from your aggregator.
+If you are using our sandbox SDK, check info and installation of de Sandbox SDK [here](/docs/sdkreference)
 
 ### Backend flow
 

--- a/catalog/simswap/simswap.md
+++ b/catalog/simswap/simswap.md
@@ -4,11 +4,12 @@ excerpt: The SIM Swap API from Open Gateway allows to check for SIM card swaps f
 category: 66aa4f941e51e7000fa353ce
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 The standardized SIM Swap API enables seamless integration of SIM swap detection and management functionality into your applications. This API enhances security by identifying potentially fraudulent activity and providing an additional layer of protection against unauthorized access.
 
 Additionally, the SIM Swap's Unified API Access feature ensures access to network capabilities of various carriers through a single, standardized interface. This simplifies integration and improves efficiency for developers by consolidating access to multiple carrier networks.
+
+> 📘 Want to give it a try?
+> Apply to join the [Developer Hub](https://opengateway.telefonica.com/en/developer-hub) and gain access to our Sandbox.
 
 ## Overview of the SIM Swap CAMARA API
 

--- a/gettingstarted/apireference.md
+++ b/gettingstarted/apireference.md
@@ -4,16 +4,9 @@ excerpt: Find out how to start testing the Open Gateway APIs with our tools in t
 category: 66d5624a492663000f4ed527
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
-
 An API reference is a comprehensive document that provides detailed information about an API (Application Programming Interface), including how to use its functions, methods, endpoints, parameters, and data structures. It serves as a guide for developers who want to integrate or interact with the API in their applications.
 
 In our developers’ website, you will find also a simple tool that uses your real credentials to make test calls.
-
-
-> 📘 If you do not have an application in the sandbox, [go to the Developer Hub](https://opengateway.telefonica.com/developer-hub) and sign up.
-
 
 ## Before getting started
 ### Purposes

--- a/gettingstarted/programs.md
+++ b/gettingstarted/programs.md
@@ -4,8 +4,6 @@ excerpt: Find out how to start testing the Open Gateway APIs in our Sandbox or g
 category: 66d5624a492663000f4ed527
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 # Open Gateway Programs 
 
 Once you are familiar with the Open Gateway initiative and the APIs we offer, you will want to have to access additional resources and start testing the APIs into your own prototype applications to perform proofs of concept on your use cases.

--- a/gettingstarted/sandbox/postmaninteraction.md
+++ b/gettingstarted/sandbox/postmaninteraction.md
@@ -4,8 +4,6 @@ excerpt: Learn how to explore the functionality of the Sandbox environment using
 category: 66d5624a492663000f4ed527
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 # Interact with the Open Gateway Sandbox using Postman
 
 Here you can download the postman collection <a href="https://github.com/Telefonica/opengateway-postman">Postman collection</a> and the <a href="https://github.com/Telefonica/opengateway-postman"> Sandbox enviroment</a> with variables that you will have to configure to work with your sandbox credentials. 

--- a/gettingstarted/sandbox/sandbox.md
+++ b/gettingstarted/sandbox/sandbox.md
@@ -27,7 +27,8 @@ Once you are approved in at least one of our programs and you log in to the priv
 
 ![Access to the Sandbox console from the website private area](https://github.com/Telefonica/opengateway-developers-website/raw/main/gettingstarted/sandbox/images/access.png?raw=true)
 
-> 📘 Please note that the usage of credentials granted from our Sandbox might be subject to some limitations in order to let you test without the obligations of a commercial contract. The [terms and conditions](https://opengateway.telefonica.com/en/terms-conditions-developers-hub) of our developer or partner programs will apply.
+> 📘 Note
+Please note that the usage of credentials granted from our Sandbox might be subject to some limitations in order to let you test without the obligations of a commercial contract. The [terms and conditions](https://opengateway.telefonica.com/en/terms-conditions-developers-hub) of our developer or partner programs will apply.
 
 ## Available APIs in the Sandbox
 

--- a/gettingstarted/sandbox/sdkreference.md
+++ b/gettingstarted/sandbox/sdkreference.md
@@ -4,8 +4,6 @@ excerpt: Reference guide to the Sandbox Python SDK on how to authorize, instanti
 category: 66d5624a492663000f4ed527
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 The current scope of the Sandbox SDK is limited since it is meant to showcase how an SDK integration is like. Check the [API Integration guide](/docs/apiintegration) to understand the pros and cons of using an SDK when compared to implement HTTP requests.
 
 Available languages:
@@ -59,9 +57,8 @@ Returns:
 
 ## Usage sample
 
-> 📘 These are code examples
-> 
-> Check other examples in the [catalog](../../catalog/available.md)
+> 📘  Note
+> These are code samples. Check other examples in the [catalog](/docs/samplecode_simswap)
 
 ```python
 import sys

--- a/gettingstarted/sandbox/usethesandbox.md
+++ b/gettingstarted/sandbox/usethesandbox.md
@@ -4,8 +4,6 @@ excerpt: Learn how to effectively use the Open Gateway Sandbox, a free and secur
 category: 66d5624a492663000f4ed527
 ---
 
-> 📘 To try out our APIs, visit the [Sandbox](https://opengateway.telefonica.com/developer-hub/unirse).
-
 ## Registering your application
 
 Open Gateway APIs access is granted to applications, not developers, so every application can have limited access to the scope and for the purpose it needs.
@@ -14,7 +12,8 @@ Open Gateway APIs access is granted to applications, not developers, so every ap
 
 Therefore the way to get credentials to test the APIs is to register an application in the Sandbox console. You will use your application credentials to authenticate your requests to the APIs from any test you code no matter if it is actually a comprehensive application or just a tiny script to run from the a command line interface.
 
-> 📘 To use the Sandbox, you must [join the Developer Hub](https://opengateway.telefonica.com/en/developer-hub) and enter in your [private area](https://opengateway.telefonica.com/en/profile/technical-toolbox/sandbox)
+> 📘 How to access the Open Gateway Sandbox
+> To use the Sandbox, you must [join the Developer Hub](https://opengateway.telefonica.com/en/developer-hub) and enter in your [private area](https://opengateway.telefonica.com/en/profile/technical-toolbox/sandbox)
 
 For every application you create, you will need to follow these simple steps to configure it:
 


### PR DESCRIPTION
Some improvements needed to be made:
- Broken links
- Missing title caused the whole callout text show as a title + lack of an intentional/motivational callout title
- Sandbox callout linking to the registration form directly causing confusion on the user (reported)
- Callouts to discover the Sandbox in Sandbox guides
- Prominence of the callout over the guide main description